### PR TITLE
Fixes IE11 (removes Array.from and new Set())

### DIFF
--- a/Repofile
+++ b/Repofile
@@ -2,5 +2,5 @@
     "description": "Language negotiation helpers",
     "enableIssues": true,
     "maintainers": ["Globalization"],
-    "topics": ["globalization", "locale", "bcp-47", "language negotiation"]
+    "topics": ["globalization", "locale", "bcp-47", "language-negotiation"]
 }

--- a/src/locale/matchers/LocaleMatcherDefault.ts
+++ b/src/locale/matchers/LocaleMatcherDefault.ts
@@ -67,10 +67,11 @@ class LocaleMatcherDefault implements Matcher {
 		});
 
 		const converted = candidates
+			.filter((el, i, a) => i === a.indexOf(el)) // deduplicate
 			.map(candidate => Locale.parse(candidate))
 			.filter(l => !l.hasParseError());
 
-		return Array.from(new Set(converted));
+		return converted;
 	}
 }
 


### PR DESCRIPTION
- The TypeScript transpilation process polyfills many things, like the spread operator `...array`, or `for...of`, but it does not for Array.from and new Set() This was breaking behavior in IE11.
- Fixes topics in the Repofile 

Tested on the tradeshift-ui project, using `npm link` and a Win 7 IE 11:
<img width="1001" alt="Screen Shot 2020-04-29 at 18 26 27" src="https://user-images.githubusercontent.com/284283/80620979-f6222c80-8a46-11ea-8afd-416b41e42033.png">

