### PR TITLE
SRE-2491 Set correct repo owner

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,20 @@
+
+# catalog-info.yml
+# This file contains metadata for backstage
+# Read more about available fields and annotations:
+# https://github.com/backstage/backstage
+#
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: g11n-langneg
+  description: |
+    Language negotiation helpers
+  annotations:
+    github.com/project-slug: Tradeshift/g11n-langneg # GitHub project name
+  tags:
+    - nodejs
+spec:
+  type: library
+  owner: docsapi
+  lifecycle: production


### PR DESCRIPTION
Motivation: Set owner to an active team, to ensure the codebase gets proper maintenance