### PR TITLE
fix(deps): bumped several deps versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 Language negotiation helpers
 
+## release
+
+Semantic release: (Commit conventions)
+
+No new version will be released unless specific commit message is used. See [Commit conventions](https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/master/convention.md) for details.
+If a release is expected, please fix commit messages to align with appropriate format
 
 ### Language negotiation usage
 
@@ -31,7 +37,7 @@ const result: Locale = match('pt', ['en', 'da', 'es'])
 // result == Locale.parse('en')`
 ```
 
-### Locale 
+### Locale
 
 #### Parsing (strict and lenient)
 


### PR DESCRIPTION
```
chore(ownership): add "frontenders" to maintainers
Repo owners: @Tradeshift/docsapi
Fix set-value vulnerability
Upgrade tradeshift-scripts to 3.0.1
npm audit fix
fix(deps): ZTN-5885 ZTN-5555 Bump tradeshift-scripts
chore: regenerate package-lock to fix ZTN-ZTN-6792
SRE-2491 Set correct repo owner
chore(deps): bump elliptic from 6.5.2 to 6.5.3
chore(deps): bump ini from 1.3.5 to 1.3.8
chore(deps): bump tmpl from 1.0.4 to 1.0.5
chore(deps): bump semver-regex from 3.1.2 to 3.1.3
```