### PR TITLE
fix(build): remove-npx-force-resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"license": "MIT",
 	"main": "dist/es/index.js",
 	"scripts": {
-		"preinstall": "npx npm-force-resolutions",
 		"prepublish": "npm run validate",
 		"after-success": "tradeshift-scripts travis-after-success",
 		"build": "rm -rf ./dist && tsc --downlevelIteration",


### PR DESCRIPTION
Since this a library used as a dependency in other repos, if we keep force resolutions in preinstall script, those builds will fail as it
cannot find the package-lock.json